### PR TITLE
Add support for message keys in the producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,13 @@ Usage
 require "rafka"
 
 prod = Rafka::Producer.new(host: "localhost", port: 6380)
-prod.produce("greetings", "Hello there!") # produce to topic "greetings"
+
+# Produce to topic "greetings". The message will be assigned to a random partition.
+prod.produce("greetings", "Hello there!")
+
+# Produce using a key. Two or more messages with the same key will always be assigned to the same partition.
+prod.produce("greetings", "Hello there!", key: "hi")
+prod.produce("greetings", "Hi there!", key: "hi")
 ```
 
 

--- a/lib/rafka/producer.rb
+++ b/lib/rafka/producer.rb
@@ -23,13 +23,20 @@ module Rafka
     #
     # @param topic [String]
     # @param msg [#to_s]
+    # @param key [#to_s] two or more messages with the same key will always be
+    #   assigned to the same partition.
     #
     # @example
     #   produce("greetings", "Hello there!")
-    def produce(topic, msg)
+    #
+    # @example
+    #   produce("greetings", "Hello there!", key: "hi")
+    def produce(topic, msg, key: nil)
       Rafka.wrap_errors do
         Rafka.with_retry(times: @options[:reconnect_attempts]) do
-          @redis.rpushx("topics:#{topic}", msg.to_s)
+          redis_key = "topics:#{topic}"
+          redis_key << ":#{key}" if key
+          @redis.rpushx(redis_key, msg.to_s)
         end
       end
     end


### PR DESCRIPTION
Two or more messages with the same key will always be assigned to the
same kafka partition.

This feature will enable us to guarantee a consistent message
consumption order.