### PR TITLE
Add support for batch consume mode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,10 @@ Layout/MultilineAssignmentLayout:
 #
 # Disabled Cops
 #
+Metrics/ClassLength:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
 Style/RescueStandardError:
   Enabled: false
 Style/SymbolArray:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ## master (unreleased)
 
+### Added
+
+- Support for batch consuming [[#12](https://github.com/skroutz/rafka-rb/pull/12)]
+
 ## 0.1.0 (2018-04-24)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Features
 
 - Consumer implementation
   - consumer groups
+  - support for consuming in batches
   - offsets may be managed automatically or manually
 - Producer implementation
   - support for partition hashing key


### PR DESCRIPTION
A new method, `consume_batch` facilitates consuming a batch of messages.
This is done by polling continuously until either N messages are accumulated
or T duration has passed. Both N and T are given by the user.

A companion end-to-end test will be added to Rafka: https://github.com/skroutz/rafka/pull/57