### PR TITLE
Drop support for older redis clients

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rafka (0.3.0)
-      redis (~> 3)
+      redis (~> 3, >= 3.3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -48,4 +48,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.6
+   1.16.4

--- a/lib/rafka.rb
+++ b/lib/rafka.rb
@@ -11,8 +11,7 @@ require "rafka/producer"
 module Rafka
   REDIS_DEFAULTS = {
     host: "localhost",
-    port: 6380,
-    reconnect_attempts: 5
+    port: 6380
   }.freeze
 
   def self.wrap_errors

--- a/lib/rafka.rb
+++ b/lib/rafka.rb
@@ -22,28 +22,4 @@ module Rafka
     raise ConsumeError, e.message[5..-1] if e.message.start_with?("CONS ")
     raise CommandError, e.message
   end
-
-  # redis-rb until 3.2.1 didn't retry to connect on
-  # Redis::CannotConnectError (eg. when rafka is down) so we manually retry
-  # 5 times
-  #
-  # TODO(agis): get rid of this method when we go to 3.2.1 or later, because
-  # https://github.com/redis/redis-rb/pull/476/
-  def self.with_retry(times: REDIS_DEFAULTS[:reconnect_attempts], every_sec: 1)
-    attempts = 0
-
-    begin
-      yield
-    rescue Redis::CannotConnectError => e
-      if Gem::Version.new(Redis::VERSION) < Gem::Version.new("3.2.2")
-        if attempts < times
-          attempts += 1
-          sleep every_sec
-          retry
-        end
-      end
-
-      raise e
-    end
-  end
 end

--- a/lib/rafka/consumer.rb
+++ b/lib/rafka/consumer.rb
@@ -263,9 +263,7 @@ module Rafka
 
       begin
         Rafka.wrap_errors do
-          Rafka.with_retry(times: @redis_opts[:reconnect_attempts]) do
-            msg = @redis.blpop(@blpop_arg, timeout: timeout)
-          end
+          msg = @redis.blpop(@blpop_arg, timeout: timeout)
         end
       rescue ConsumeError => e
         # redis-rb didn't automatically call `CLIENT SETNAME` until v3.2.2

--- a/lib/rafka/producer.rb
+++ b/lib/rafka/producer.rb
@@ -40,11 +40,9 @@ module Rafka
     #     produce("greetings", "Hola", key: "abc")
     def produce(topic, msg, key: nil)
       Rafka.wrap_errors do
-        Rafka.with_retry(times: @options[:reconnect_attempts]) do
-          redis_key = "topics:#{topic}"
-          redis_key << ":#{key}" if key
-          @redis.rpushx(redis_key, msg.to_s)
-        end
+        redis_key = "topics:#{topic}"
+        redis_key << ":#{key}" if key
+        @redis.rpushx(redis_key, msg.to_s)
       end
     end
 

--- a/rafka.gemspec
+++ b/rafka.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files       = Dir["{lib,test}/**/*", "CHANGELOG.md", "COPYING", "Rakefile", "README.md"]
   s.test_files  = Dir["test/**/*"]
 
-  s.add_runtime_dependency "redis", "~> 3"
+  s.add_runtime_dependency "redis", "~> 3", ">= 3.3.2"
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
Tested with [rafka end-to-end tests](https://github.com/skroutz/rafka/tree/master/test).