### PR TITLE
Pluralize the :topic initialization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ for more information.
 ### Consumer
 
 ```ruby
-consumer = Rafka::Consumer.new(topics: "greetings", group: "myapp")
+consumer = Rafka::Consumer.new(topic: "greetings", group: "myapp")
 msg = consumer.consume
 msg.value # => "Hello there!"
 
@@ -88,7 +88,7 @@ Offsets are managed automatically by default. If you need more control you can
 turn off the feature and manually commit offsets:
 
 ```ruby
-consumer = Rafka::Consumer.new(topics: "greetings", group: "myapp", auto_offset_commit: false)
+consumer = Rafka::Consumer.new(topic: "greetings", group: "myapp", auto_offset_commit: false)
 
 # commit a single offset
 msg = consumer.consume
@@ -111,9 +111,9 @@ consumer = Rafka::Consumer.new(
 Consumers can subscribe to multiple topics:
 
 ```ruby
-consumer = Rafka::Consumer.new(topics: "topic_1")
-consumer = Rafka::Consumer.new(topics: ["topic_1", "topic_2"])
-consumer = Rafka::Consumer.new(topics: "topic_1,topic_2")
+consumer = Rafka::Consumer.new(topic: "topic_1")
+consumer = Rafka::Consumer.new(topic: ["topic_1", "topic_2"])
+consumer = Rafka::Consumer.new(topic: "topic_1,topic_2")
 ```
 
 Refer to the [Consumer API documentation](http://www.rubydoc.info/github/skroutz/rafka-rb/Rafka/Consumer)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ for more information.
 ### Consumer
 
 ```ruby
-consumer = Rafka::Consumer.new(topic: "greetings", group: "myapp")
+consumer = Rafka::Consumer.new(topics: "greetings", group: "myapp")
 msg = consumer.consume
 msg.value # => "Hello there!"
 
@@ -88,7 +88,7 @@ Offsets are managed automatically by default. If you need more control you can
 turn off the feature and manually commit offsets:
 
 ```ruby
-consumer = Rafka::Consumer.new(topic: "greetings", group: "myapp", auto_offset_commit: false)
+consumer = Rafka::Consumer.new(topics: "greetings", group: "myapp", auto_offset_commit: false)
 
 # commit a single offset
 msg = consumer.consume
@@ -104,8 +104,16 @@ Consumers may also set their own custom [librdkafka configuration](https://githu
 
 ```ruby
 consumer = Rafka::Consumer.new(
-  topic: "greetings", group: "myapp", librdkafka: { "auto.offset.reset" => "earliest" }
+  topics: "greetings", group: "myapp", librdkafka: { "auto.offset.reset" => "earliest" }
 )
+```
+
+Consumers can subscribe to multiple topics:
+
+```ruby
+consumer = Rafka::Consumer.new(topics: "topic_1")
+consumer = Rafka::Consumer.new(topics: ["topic_1", "topic_2"])
+consumer = Rafka::Consumer.new(topics: "topic_1,topic_2")
 ```
 
 Refer to the [Consumer API documentation](http://www.rubydoc.info/github/skroutz/rafka-rb/Rafka/Consumer)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Consumers may also set their own custom [librdkafka configuration](https://githu
 
 ```ruby
 consumer = Rafka::Consumer.new(
-  topics: "greetings", group: "myapp", librdkafka: { "auto.offset.reset" => "earliest" }
+  topic: "greetings", group: "myapp", librdkafka: { "auto.offset.reset" => "earliest" }
 )
 ```
 

--- a/lib/rafka/consumer.rb
+++ b/lib/rafka/consumer.rb
@@ -10,7 +10,7 @@ module Rafka
   class Consumer
     include GenericCommands
 
-    REQUIRED_OPTS = [:group, :topics].freeze
+    REQUIRED_OPTS = [:group, :topic].freeze
 
     # @return [Redis::Client] the underlying Redis client instance
     attr_reader :redis
@@ -23,7 +23,7 @@ module Rafka
     # @param [Hash] opts
     # @option opts [String] :host ("localhost") server hostname
     # @option opts [Fixnum] :port (6380) server port
-    # @option opts [Array<String>|String] :topics Kafka topics to consume (required)
+    # @option opts [Array<String>|String] :topic Kafka topics to consume (required)
     # @option opts [String] :group Kafka consumer group name (required)
     # @option opts [String] :id (random) Kafka consumer id
     # @option opts [Boolean] :auto_commit (true) automatically commit
@@ -47,7 +47,7 @@ module Rafka
 
       @rafka_opts, @redis_opts = parse_opts(opts)
       @redis = Redis.new(@redis_opts)
-      @blpop_arg = "topics:#{@rafka_opts[:topics]}"
+      @blpop_arg = "topics:#{@rafka_opts[:topic]}"
       @blpop_arg << ":#{opts[:librdkafka].to_json}" if !opts[:librdkafka].empty?
     end
 
@@ -206,8 +206,8 @@ module Rafka
 
       # Support array of strings but make sure you turn this into a
       # comma-separated string of topics if that's the case.
-      if rafka_opts[:topics].is_a? Array
-        rafka_opts[:topics] = rafka_opts[:topics].join(",")
+      if rafka_opts[:topic].is_a? Array
+        rafka_opts[:topic] = rafka_opts[:topic].join(",")
       end
 
       redis_opts = REDIS_DEFAULTS.dup.merge(opts[:redis] || {})

--- a/lib/rafka/consumer.rb
+++ b/lib/rafka/consumer.rb
@@ -2,7 +2,7 @@ require "json"
 require "securerandom"
 
 module Rafka
-  # A Rafka-backed Kafka consumer that consumes messages from a specific topic
+  # A Rafka-backed Kafka consumer that consumes messages from specific topics
   # and belongs to a specific consumer group. Offsets may be committed
   # automatically or manually.
   #
@@ -10,7 +10,7 @@ module Rafka
   class Consumer
     include GenericCommands
 
-    REQUIRED_OPTS = [:group, :topic].freeze
+    REQUIRED_OPTS = [:group, :topics].freeze
 
     # @return [Redis::Client] the underlying Redis client instance
     attr_reader :redis
@@ -23,7 +23,7 @@ module Rafka
     # @param [Hash] opts
     # @option opts [String] :host ("localhost") server hostname
     # @option opts [Fixnum] :port (6380) server port
-    # @option opts [String] :topic Kafka topic to consume (required)
+    # @option opts [Array<String>|String] :topics Kafka topics to consume (required)
     # @option opts [String] :group Kafka consumer group name (required)
     # @option opts [String] :id (random) Kafka consumer id
     # @option opts [Boolean] :auto_commit (true) automatically commit
@@ -47,7 +47,7 @@ module Rafka
 
       @rafka_opts, @redis_opts = parse_opts(opts)
       @redis = Redis.new(@redis_opts)
-      @blpop_arg = "topics:#{@rafka_opts[:topic]}"
+      @blpop_arg = "topics:#{@rafka_opts[:topics]}"
       @blpop_arg << ":#{opts[:librdkafka].to_json}" if !opts[:librdkafka].empty?
     end
 
@@ -199,10 +199,16 @@ module Rafka
     # @return [Array<Hash, Hash>] rafka opts, redis opts
     def parse_opts(opts)
       REQUIRED_OPTS.each do |opt|
-        raise "#{opt.inspect} option not provided" if opts[opt].nil?
+        raise "#{opt.inspect} option not provided" if opts[opt].nil? || opts[opt].empty?
       end
 
       rafka_opts = opts.reject { |k| k == :redis || k == :librdkafka }
+
+      # Support array of strings but make sure you turn this into a
+      # comma-separated string of topics if that's the case.
+      if rafka_opts[:topics].is_a? Array
+        rafka_opts[:topics] = rafka_opts[:topics].join(",")
+      end
 
       redis_opts = REDIS_DEFAULTS.dup.merge(opts[:redis] || {})
       redis_opts.merge!(

--- a/test/consumer_test.rb
+++ b/test/consumer_test.rb
@@ -3,7 +3,7 @@ require "rafka"
 
 class ConsumerTest < Minitest::Test
   def test_prepare_for_commit
-    consumer = Rafka::Consumer.new(group: "foo", topic: "bar")
+    consumer = Rafka::Consumer.new(group: "foo", topics: "bar")
 
     msgs = [
       ["topic", "foo", "partition", 0, "offset", 1, "value", "a"],
@@ -44,7 +44,7 @@ class ConsumerTest < Minitest::Test
   end
 
   def test_consume_block_no_message
-    cons = Rafka::Consumer.new(group: "foo", topic: "bar")
+    cons = Rafka::Consumer.new(group: "foo", topics: "bar")
 
     def cons.consume_one(_)
       nil
@@ -57,17 +57,17 @@ class ConsumerTest < Minitest::Test
 
   def test_blpop_arg
     cons = Rafka::Consumer.new(
-      group: "foo", topic: "bar", librdkafka: { test1: 2, test2: "a", "foo.bar" => true }
+      group: "foo", topics: "bar", librdkafka: { test1: 2, test2: "a", "foo.bar" => true }
     )
     assert_equal cons.blpop_arg, 'topics:bar:{"test1":2,"test2":"a","foo.bar":true}'
 
-    cons = Rafka::Consumer.new(group: "foo", topic: "bar", librdkafka: {})
+    cons = Rafka::Consumer.new(group: "foo", topics: "bar", librdkafka: {})
     assert_equal cons.blpop_arg, "topics:bar"
 
-    cons = Rafka::Consumer.new(group: "foo", topic: "bar", librdkafka: nil)
+    cons = Rafka::Consumer.new(group: "foo", topics: "bar", librdkafka: nil)
     assert_equal cons.blpop_arg, "topics:bar"
 
-    cons = Rafka::Consumer.new(group: "foo", topic: "bar")
+    cons = Rafka::Consumer.new(group: "foo", topics: "bar")
     assert_equal cons.blpop_arg, "topics:bar"
   end
 end

--- a/test/consumer_test.rb
+++ b/test/consumer_test.rb
@@ -3,7 +3,7 @@ require "rafka"
 
 class ConsumerTest < Minitest::Test
   def test_prepare_for_commit
-    consumer = Rafka::Consumer.new(group: "foo", topics: "bar")
+    consumer = Rafka::Consumer.new(group: "foo", topic: "bar")
 
     msgs = [
       ["topic", "foo", "partition", 0, "offset", 1, "value", "a"],
@@ -44,7 +44,7 @@ class ConsumerTest < Minitest::Test
   end
 
   def test_consume_block_no_message
-    cons = Rafka::Consumer.new(group: "foo", topics: "bar")
+    cons = Rafka::Consumer.new(group: "foo", topic: "bar")
 
     def cons.consume_one(_)
       nil
@@ -57,17 +57,22 @@ class ConsumerTest < Minitest::Test
 
   def test_blpop_arg
     cons = Rafka::Consumer.new(
-      group: "foo", topics: "bar", librdkafka: { test1: 2, test2: "a", "foo.bar" => true }
+      group: "foo", topic: "bar", librdkafka: { test1: 2, test2: "a", "foo.bar" => true }
     )
     assert_equal cons.blpop_arg, 'topics:bar:{"test1":2,"test2":"a","foo.bar":true}'
 
-    cons = Rafka::Consumer.new(group: "foo", topics: "bar", librdkafka: {})
+    cons = Rafka::Consumer.new(group: "foo", topic: "bar", librdkafka: {})
     assert_equal cons.blpop_arg, "topics:bar"
 
-    cons = Rafka::Consumer.new(group: "foo", topics: "bar", librdkafka: nil)
+    cons = Rafka::Consumer.new(group: "foo", topic: "bar", librdkafka: nil)
     assert_equal cons.blpop_arg, "topics:bar"
 
-    cons = Rafka::Consumer.new(group: "foo", topics: "bar")
+    cons = Rafka::Consumer.new(group: "foo", topic: "bar")
     assert_equal cons.blpop_arg, "topics:bar"
+  end
+
+  def test_multiple_topics
+    cons = Rafka::Consumer.new(group: "foo", topic: %w[foo bar])
+    assert_equal cons.blpop_arg, "topics:foo,bar"
   end
 end


### PR DESCRIPTION
By default, kafka and kafka-go support consumers subscribing to
multiple topics, by passing an array of strings.

Rafka also respects [this](https://github.com/skroutz/rafka/blob/3414a204c1697c860b7b4a1d68181b8cbd263374/server.go#L433).

Rafka-rb simply needs to change the wording in order to respect
the plural and in effect show the api user that consuming from
multiple topics is supported.

The commit takes the extra step of supporting an array of strings
as well as a single string, whether it contains a single topic or
multiple comma-separated topics.

Closes #5