### PR TITLE
gemspec: Relax redis gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ## master (unreleased)
 
+### Changed
 
-
-
+- Relax redis-rb dependency to support v4.0.0 or later [[#21](https://github.com/skroutz/rafka-rb/pull/21)]
 
 
 ## 0.4.0 (2018-09-04)

--- a/rafka.gemspec
+++ b/rafka.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files       = Dir["{lib,test}/**/*", "CHANGELOG.md", "COPYING", "Rakefile", "README.md"]
   s.test_files  = Dir["test/**/*"]
 
-  s.add_runtime_dependency "redis", "~> 3", ">= 3.3.2"
+  s.add_runtime_dependency "redis", ">= 3.3.2"
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This adds support for redis-rb 4.X.X