### PR TITLE
Consumer: Handle disconnection errors on committing offsets

### DIFF
--- a/lib/rafka/consumer.rb
+++ b/lib/rafka/consumer.rb
@@ -1,5 +1,6 @@
 require "json"
 require "securerandom"
+require "logger"
 
 module Rafka
   # A Rafka-backed Kafka consumer that consumes messages from a specific topic
@@ -17,6 +18,8 @@ module Rafka
 
     # @return [String] the argument passed to BLPOP
     attr_reader :blpop_arg
+
+    attr_accessor :logger
 
     # Initialize a new consumer.
     #
@@ -49,6 +52,10 @@ module Rafka
       @redis = Redis.new(@redis_opts)
       @blpop_arg = "topics:#{@rafka_opts[:topic]}"
       @blpop_arg << ":#{opts[:librdkafka].to_json}" if !opts[:librdkafka].empty?
+
+      # Initialize with a default logger
+      @logger = Logger.new($stdout)
+      @logger.level = Logger::INFO
     end
 
     # Consumes the next message.


### PR DESCRIPTION
TL;DR: Added Logger and handle disconnection errors on committing offsets.

----

When the consumer client gets disconnected from its rafka before committing its offsets
`@redis.rpush("acks")` fails with the error, as other/new rafka has lost the details for
this client that is kept in its memory.
```
CONS No consumer registered for Client 1233XYZ
```

Upon such errors `@redis.blpop`, reconnects with the rafka and reregister the client.
Since disconnections, can be common and during consuming a message with `blpop` they are
autoresolved, we want similar behavior of self healing also during committing offsets.
However after a reconnection, it is not safe to commit anything as another consumer
might have already taken over the partition, we just log the disconnection event and leave the
offsets uncommitted for the next consume event to commit after reregister properly with blpop.

This will result to reprocessing some of the messages, but reprocessing the same message is part
of the kafka message processing specification, that guaranties at-least-one delivery of a message.
Consumers are already designed to handle this in their implementation.

If any other error is send from rafka server, it will be reraised as before to the client.